### PR TITLE
[gh-migrate] run astgrep rules/actions-breaking-change/ubuntu-latest-250117.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: cli/gh-extension-precompile@v1


### PR DESCRIPTION
This PR is created by [gh-migrate](https://github.com/HikaruEgashira/gh-migrate)
---
```yaml
# yaml-language-server: $schema=https://raw.githubusercontent.com/ast-grep/ast-grep/main/schemas/rule.json
id: ubuntu-latest-250117
language: yml
rule: {pattern: "runs-on: ubuntu-latest"}
fix: "runs-on: ubuntu-24.04"
message: "Ubuntu-latest upcoming breaking changes"
files:
  - '**/.github/workflows/**'

```